### PR TITLE
Errorlist type alias

### DIFF
--- a/src/Rails/Decode.elm
+++ b/src/Rails/Decode.elm
@@ -1,6 +1,9 @@
-module Rails.Decode (errors) where
+module Rails.Decode (errors, ErrorList) where
 
 {-|
+
+Types
+@docs ErrorList
 
 # Decoding
 @docs errors
@@ -11,6 +14,19 @@ import Json.Decode as Decode exposing (Decoder, (:=))
 import Result exposing (Result)
 import Dict
 
+{-| ErrorList is a type alias for
+a list of fields to String, where `field` is expected to be a type for matching
+errors to
+```
+
+type Field = Name | Password
+
+decode : ErrorList Field
+
+```
+-}
+type alias ErrorList field =
+    List (field, String)
 
 -- Decoding
 
@@ -32,17 +48,18 @@ Dict.fromList
     ]
 
 -}
+errors : Dict.Dict String field -> Decoder (ErrorList field)
 errors mappings =
     let
         errorsDecoder : Decoder (List (String, List String))
         errorsDecoder =
             Decode.keyValuePairs (Decode.list Decode.string)
 
-        finalDecoder : Decoder (List (field, String))
+        --finalDecoder : Decoder (ErrorList b)
         finalDecoder =
             Decode.customDecoder errorsDecoder (toFinalDecoder [])
 
-        fieldDecoderFor : String -> Decoder field
+        --fieldDecoderFor : String -> Decoder field
         fieldDecoderFor fieldName =
             Dict.get fieldName mappings
                 |> Maybe.map Decode.succeed
@@ -57,7 +74,7 @@ errors mappings =
 
                 (fieldName, errors) :: others ->
                     let
-                        newResults : Result String (List (field, String))
+                        --newResults : Result String (ErrorList d)
                         newResults =
                             Decode.decodeString (fieldDecoderFor fieldName) ("\"" ++ fieldName ++ "\"")
                                 |> Result.map (tuplesFromField errors results)
@@ -70,7 +87,7 @@ errors mappings =
                             Ok newResultList ->
                                 toFinalDecoder newResultList others
 
-        tuplesFromField : List String -> List (field, String) -> field -> List (field, String)
+        --tuplesFromField : List String -> (ErrorList field) -> field -> (ErrorList g)
         tuplesFromField errors results field =
             errors
                 |> List.map (\error -> (field, error))

--- a/src/Rails/Decode.elm
+++ b/src/Rails/Decode.elm
@@ -55,7 +55,7 @@ errors mappings =
         errorsDecoder =
             Decode.keyValuePairs (Decode.list Decode.string)
 
-        --finalDecoder : Decoder (ErrorList b)
+        --finalDecoder : Decoder (ErrorList field)
         finalDecoder =
             Decode.customDecoder errorsDecoder (toFinalDecoder [])
 
@@ -74,7 +74,7 @@ errors mappings =
 
                 (fieldName, errors) :: others ->
                     let
-                        --newResults : Result String (ErrorList d)
+                        --newResults : Result String (ErrorList field)
                         newResults =
                             Decode.decodeString (fieldDecoderFor fieldName) ("\"" ++ fieldName ++ "\"")
                                 |> Result.map (tuplesFromField errors results)
@@ -87,7 +87,7 @@ errors mappings =
                             Ok newResultList ->
                                 toFinalDecoder newResultList others
 
-        --tuplesFromField : List String -> (ErrorList field) -> field -> (ErrorList g)
+        --tuplesFromField : List String -> (ErrorList field) -> field -> (ErrorList field)
         tuplesFromField errors results field =
             errors
                 |> List.map (\error -> (field, error))


### PR DESCRIPTION
# What I changed
- Top level type sigs are needed for publishing packages properly - so I've commented out those out to make the top level one work
- Added a type alias so that instead of writing `List (field, String)` everywhere you can instead do `ErrorList field`
# Motivation

First, consider the following type signatures:

``` elm
attemptLogin : String -> String -> String -> Decoder (List ( field, String )) -> Task Http.Error (List (field, String))
```

compared to

``` elm
attemptLogin : String -> String -> String -> Decoder (ErrorList field) -> Task Http.Error (ErrorList field)
```

In our second example, we abstract the concept of list of errors away from the programmer - as `Rails.Decode.errors` takes a `Dict String field`, the underlying implementation of ErrorList could change, but still make their type signatures valid up to the point where it actually matters (when the `ErrorList` sees first use).

Now, consider the following: 

``` elm

type Field = ..

type alias MyErrors = List (Field, String)

attemptLogin : String -> String -> String -> Decoder (List ( field, String )) -> Task Http.Error (List (field, String))
```

compared to

``` elm

type Field = ..

type alias MyErrors = ErrorList Field

attemptLogin : String -> String -> String -> Decoder MyErrors -> Task Http.Error MyErrors
```

Basically, abstract away the concept of a Rails ErrorList, so it's not only more readable but more expressive. 
