### PR TITLE
Add a helper for grabbing auth tokens + examples

### DIFF
--- a/elm-package.json
+++ b/elm-package.json
@@ -10,6 +10,7 @@
         "Rails",
         "Rails.Decode"
     ],
+    "native-modules": true,
     "dependencies": {
         "elm-lang/core": "2.1.0 <= v < 4.0.0",
         "evancz/elm-http": "2.0.0 <= v < 4.0.0"

--- a/examples/Main.elm
+++ b/examples/Main.elm
@@ -5,6 +5,7 @@ import Rails
 import Graphics.Element exposing (show)
 
 main =
-    case Rails.authToken of
-        Nothing -> show "nothing"
+    case Rails.csrfToken of
+        Nothing -> show "Nothing"
         Just v -> show v
+        _ -> show Rails.csrfToken

--- a/examples/Main.elm
+++ b/examples/Main.elm
@@ -1,0 +1,10 @@
+module Main where
+
+import Rails
+
+import Graphics.Element exposing (show)
+
+main =
+    case Rails.authToken of
+        Nothing -> show "nothing"
+        Just v -> show v

--- a/examples/index.html
+++ b/examples/index.html
@@ -1,0 +1,13 @@
+<html>
+    <meta content="0QmGzPRL59HYloQ/lsmInAhu0ld9JiU1/KYkK9/axRc=" name="csrf-token">
+
+    <script type="text/javascript" src="elm.js"></script>
+
+    <body>
+
+        <script>
+            Elm.fullscreen(Elm.Main);
+        </script>
+    </body>
+
+</html>

--- a/src/Native/Rails.js
+++ b/src/Native/Rails.js
@@ -13,8 +13,7 @@ Elm.Native.Rails.make = function(localRuntime) {
     var metaNode = document.querySelector('meta[name="csrf-token"]');
 
     var authToken = (function() {
-        if (metaNode === null){
-            console.log(metaNode);
+        if (metaNode === null || typeof metaNode.content === "undefined"){
             return $Maybe.Nothing;
         }
         return $Maybe.Just(metaNode.content);

--- a/src/Native/Rails.js
+++ b/src/Native/Rails.js
@@ -10,22 +10,10 @@ Elm.Native.Rails.make = function(localRuntime) {
 
     var $Maybe = Elm.Maybe.make(localRuntime);
 
-    var csrfTokenName = "csrf-token"
-    var csrfToken = $Maybe.Nothing;
-    var potentialMetaNodes = document.head.childNodes;
-
-    // Use this instead of document.querySelector() for pre-ES5 compatibility.
-    for (var index in potentialMetaNodes) {
-        var potentialMetaNode = potentialMetaNodes[index];
-
-        if (potentialMetaNode.tagName === "META"
-            && potentialMetaNode.name === csrfTokenName
-            && (typeof potentialMetaNode.content) === "string")
-        {
-            csrfToken = $Maybe.Just(potentialMetaNode.content);;
-            break;
-        }
-    }
+    var csrfTokenNode = document.querySelector('meta[name="csrf-token"]');
+    var csrfToken = (function() {
+        return (csrfTokenNode === null || (typeof csrfTokenNode.content) !== "string") ? $Maybe.Nothing : $Maybe.Just(csrfTokenNode.content);
+    })();
 
     return localRuntime.Native.Rails.values = {
         csrfToken : csrfToken

--- a/src/Native/Rails.js
+++ b/src/Native/Rails.js
@@ -10,10 +10,22 @@ Elm.Native.Rails.make = function(localRuntime) {
 
     var $Maybe = Elm.Maybe.make(localRuntime);
 
-    var csrfTokenNode = document.querySelector('meta[name="csrf-token"]');
-    var csrfToken = (function() {
-        return (csrfTokenNode === null || tyepof csrfTokenNode.content === "undefined") ? $Maybe.Nothing : $Maybe.Just(csrfTokenNode.content);
-    })();
+    var csrfTokenName = "csrf-token"
+    var csrfToken = $Maybe.Nothing;
+    var potentialMetaNodes = document.head.childNodes;
+
+    // Use this instead of document.querySelector() for pre-ES5 compatibility.
+    for (var index in potentialMetaNodes) {
+        var potentialMetaNode = potentialMetaNodes[index];
+
+        if (potentialMetaNode.tagName === "META"
+            && potentialMetaNode.name === csrfTokenName
+            && (typeof potentialMetaNode.content) === "string")
+        {
+            csrfToken = $Maybe.Just(potentialMetaNode.content);;
+            break;
+        }
+    }
 
     return localRuntime.Native.Rails.values = {
         csrfToken : csrfToken

--- a/src/Native/Rails.js
+++ b/src/Native/Rails.js
@@ -1,0 +1,26 @@
+Elm.Native = Elm.Native || {};
+Elm.Native.Rails = {};
+Elm.Native.Rails.make = function(localRuntime) {
+    localRuntime.Native = localRuntime.Native || {};
+    localRuntime.Native.Rails = localRuntime.Native.Rails || {};
+    if (localRuntime.Native.Rails.values)
+    {
+        return localRuntime.Native.Rails.values;
+    }
+
+    var NS = Elm.Native.Signal.make(localRuntime);
+    var Utils = Elm.Native.Utils.make(localRuntime);
+
+    var metaNode = document.querySelector('meta[name="csrf-token"]');
+
+    var authToken = (function() {
+        if (metaNode === null){
+            return "";
+        }
+        return metaNode.content;
+    })();
+
+    return localRuntime.Native.Rails.values = {
+        authToken : authToken
+    };
+}

--- a/src/Native/Rails.js
+++ b/src/Native/Rails.js
@@ -10,16 +10,12 @@ Elm.Native.Rails.make = function(localRuntime) {
 
     var $Maybe = Elm.Maybe.make(localRuntime);
 
-    var metaNode = document.querySelector('meta[name="csrf-token"]');
-
-    var authToken = (function() {
-        if (metaNode === null || typeof metaNode.content === "undefined"){
-            return $Maybe.Nothing;
-        }
-        return $Maybe.Just(metaNode.content);
+    var csrfTokenNode = document.querySelector('meta[name="csrf-token"]');
+    var csrfToken = (function() {
+        return (csrfTokenNode === null || tyepof csrfTokenNode.content === "undefined") ? $Maybe.Nothing : $Maybe.Just(csrfTokenNode.content);
     })();
 
     return localRuntime.Native.Rails.values = {
-        authToken : authToken
+        csrfToken : csrfToken
     };
 }

--- a/src/Native/Rails.js
+++ b/src/Native/Rails.js
@@ -11,9 +11,10 @@ Elm.Native.Rails.make = function(localRuntime) {
     var $Maybe = Elm.Maybe.make(localRuntime);
 
     var csrfTokenNode = document.head.querySelector('meta[name="csrf-token"]');
-    var csrfToken = (function() {
-        return (csrfTokenNode === null || (typeof csrfTokenNode.content) !== "string") ? $Maybe.Nothing : $Maybe.Just(csrfTokenNode.content);
-    })();
+    var csrfToken =
+        (csrfTokenNode === null || (typeof csrfTokenNode.content !== "string"))
+            ? $Maybe.Nothing
+            : $Maybe.Just(csrfTokenNode.content);
 
     return localRuntime.Native.Rails.values = {
         csrfToken : csrfToken

--- a/src/Native/Rails.js
+++ b/src/Native/Rails.js
@@ -10,7 +10,7 @@ Elm.Native.Rails.make = function(localRuntime) {
 
     var $Maybe = Elm.Maybe.make(localRuntime);
 
-    var csrfTokenNode = document.querySelector('meta[name="csrf-token"]');
+    var csrfTokenNode = document.head.querySelector('meta[name="csrf-token"]');
     var csrfToken = (function() {
         return (csrfTokenNode === null || (typeof csrfTokenNode.content) !== "string") ? $Maybe.Nothing : $Maybe.Just(csrfTokenNode.content);
     })();

--- a/src/Native/Rails.js
+++ b/src/Native/Rails.js
@@ -8,16 +8,16 @@ Elm.Native.Rails.make = function(localRuntime) {
         return localRuntime.Native.Rails.values;
     }
 
-    var NS = Elm.Native.Signal.make(localRuntime);
-    var Utils = Elm.Native.Utils.make(localRuntime);
+    var $Maybe = Elm.Maybe.make(localRuntime);
 
     var metaNode = document.querySelector('meta[name="csrf-token"]');
 
     var authToken = (function() {
         if (metaNode === null){
-            return "";
+            console.log(metaNode);
+            return $Maybe.Nothing;
         }
-        return metaNode.content;
+        return $Maybe.Just(metaNode.content);
     })();
 
     return localRuntime.Native.Rails.values = {

--- a/src/Rails.elm
+++ b/src/Rails.elm
@@ -1,15 +1,21 @@
-module Rails (Error(..), get, post, send, fromJson, always, decoder) where
+module Rails (Error(..), get, post, send, fromJson, always, decoder, authToken) where
 
 {-|
 
 # Http
 @docs Error, get, post, send, fromJson, always, decoder
 
+# Tokens
+@docs authToken
+
 -}
 
 import Http
 import Task exposing (Task, succeed, fail, mapError, andThen)
 import Json.Decode exposing (Decoder, decodeString)
+
+
+import Native.Rails
 
 
 -- Http
@@ -167,6 +173,18 @@ handleResponse onSuccess onError response =
               case response.value of
                 Http.Text str -> onError response str
                 _ -> fail unexpectedPayloadError
+
+
+{-| get the rails authToken from the meta tag
+returns nothing if the tag doesn't exist
+-}
+authToken : Maybe String
+authToken =
+    let
+        auth = Native.Rails.authToken
+    in
+        if auth == "" then Nothing
+        else Just auth
 
 
 (=>) = (,)

--- a/src/Rails.elm
+++ b/src/Rails.elm
@@ -175,8 +175,11 @@ handleResponse onSuccess onError response =
                 _ -> fail unexpectedPayloadError
 
 
-{-| get the rails csrfToken from the meta tag
-returns nothing if the tag doesn't exist
+{-| If there was a `<meta name="csrf-token">` tag in the page's `<head>` when
+elm-rails loaded, returns the value its `content` attribute had at that time.
+
+Rails expects this value in the `X-CSRF-Token` header for non-`GET` requests as
+a [CSRF countermeasure](http://guides.rubyonrails.org/security.html#csrf-countermeasures).
 -}
 csrfToken : Maybe String
 csrfToken = Native.Rails.csrfToken

--- a/src/Rails.elm
+++ b/src/Rails.elm
@@ -13,7 +13,7 @@ module Rails (Error(..), get, post, send, fromJson, always, decoder, authToken) 
 import Http
 import Task exposing (Task, succeed, fail, mapError, andThen)
 import Json.Decode exposing (Decoder, decodeString)
-
+import Maybe
 
 import Native.Rails
 
@@ -179,12 +179,7 @@ handleResponse onSuccess onError response =
 returns nothing if the tag doesn't exist
 -}
 authToken : Maybe String
-authToken =
-    let
-        auth = Native.Rails.authToken
-    in
-        if auth == "" then Nothing
-        else Just auth
+authToken = Native.Rails.authToken
 
 
 (=>) = (,)

--- a/src/Rails.elm
+++ b/src/Rails.elm
@@ -15,18 +15,17 @@ import Task exposing (Task, succeed, fail, mapError, andThen)
 import Json.Decode exposing (Decoder, decodeString)
 import Maybe
 import String
-
 import Native.Rails
-import String
 
 
 -- Http
 
+
 {-| The kinds of errors a Rails server may return.
 -}
 type Error error
-    = HttpError Http.Error
-    | RailsError error
+  = HttpError Http.Error
+  | RailsError error
 
 
 {-| Send a GET request to the given URL. You also specify how to decode the response.
@@ -35,27 +34,27 @@ type Error error
 
     hats : Task (Error (List String)) (List String)
     hats =
-        get (decoder (list string) (succeed ())) "http://example.com/hat-categories.json"
+      get (decoder (list string) (succeed ())) "http://example.com/hat-categories.json"
 
 -}
 get : ResponseDecoder error value -> String -> Task (Error error) value
 get decoder url =
-    fromJson decoder (send "GET" url Http.empty)
+  fromJson decoder (send "GET" url Http.empty)
 
 
 {-| Send a POST request to the given URL. You also specify how to decode the response.
 
-    import Json.Decode (list, string)
-    import Http
+  import Json.Decode (list, string)
+  import Http
 
-    hats : Task (Error (List String)) (List String)
-    hats =
-        post (decoder (list string) (succeed ())) "http://example.com/hat-categories.json" Http.empty
+  hats : Task (Error (List String)) (List String)
+  hats =
+    post (decoder (list string) (succeed ())) "http://example.com/hat-categories.json" Http.empty
 
 -}
 post : ResponseDecoder error value -> String -> Http.Body -> Task (Error error) value
 post decoder url body =
-    fromJson decoder (send "POST" url body)
+  fromJson decoder (send "POST" url body)
 
 
 {-| Utility for working with Rails. Wraps Http.send, passing an Authenticity Token along with the type of request. Suitable for use with `fromJson`:
@@ -68,73 +67,74 @@ post decoder url body =
     hats : HatStyle -> Task (Error (List String)) (List String)
     hats style =
 
-        let
-            payload =
-                Encode.object
-                    [ ( "style", encodeHatStyle style ) ]
+      let
+        payload =
+          Encode.object
+            [ ( "style", encodeHatStyle style ) ]
 
-            body =
-                Http.string (Encode.encode 0 payload)
+        body =
+          Http.string (Encode.encode 0 payload)
 
-            success =
-                list string
+        success =
+          list string
 
-            failure =
-                Dict.fromList [ ("style", HatStyle) ]
-                    |> Rails.Decode.errors
-        in
-            send "POST" url body
-                |> fromJson (decoder success failure)
+        failure =
+          Dict.fromList [ ("style", HatStyle) ]
+            |> Rails.Decode.errors
+      in
+        send "POST" url body
+          |> fromJson (decoder success failure)
 -}
 send : String -> String -> Http.Body -> Task Http.RawError Http.Response
 send verb url body =
-    let
-        csrfTokenString =
-            Maybe.withDefault "" csrfToken
+  let
+    csrfTokenString =
+      Maybe.withDefault "" csrfToken
 
-        csrfTokenHeaders =
-            if (String.isEmpty csrfTokenString)
-                || ((String.toUpper verb) == "GET")
-            then
-                []
-            else
-                [ "X-CSRF-Token" => csrfTokenString ]
+    csrfTokenHeaders =
+      if
+        (String.isEmpty csrfTokenString)
+          || ((String.toUpper verb) == "GET")
+      then
+        []
+      else
+        [ "X-CSRF-Token" => csrfTokenString ]
 
-        requestSettings =
-            { verb = verb
-            , headers =
-                csrfTokenHeaders ++
-                    [ "Content-Type" => "application/json"
-                    , "Accept" => "application/json, text/javascript, */*; q=0.01"
-                    , "X-Requested-With" => "XMLHttpRequest"
-                    ]
-            , url = url
-            , body = body
-            }
-    in
-        Http.send Http.defaultSettings requestSettings
+    requestSettings =
+      { verb = verb
+      , headers =
+          csrfTokenHeaders
+            ++ [ "Content-Type" => "application/json"
+               , "Accept" => "application/json, text/javascript, */*; q=0.01"
+               , "X-Requested-With" => "XMLHttpRequest"
+               ]
+      , url = url
+      , body = body
+      }
+  in
+    Http.send Http.defaultSettings requestSettings
 
 
 {-| JSON Decoders for parsing an HTTP response body.
 -}
 type alias ResponseDecoder error value =
-    { success : Decoder value
-    , failure : Decoder error
-    }
+  { success : Decoder value
+  , failure : Decoder error
+  }
 
 
 {-| Returns a decoder suitable for passing to `fromJson`, which uses the same decoder for both success and failure responses.
 -}
 always : Decoder value -> ResponseDecoder value value
 always decoder =
-    ResponseDecoder decoder decoder
+  ResponseDecoder decoder decoder
 
 
 {-| Returns a decoder suitable for passing to `fromJson`.
 -}
 decoder : Decoder value -> Decoder error -> ResponseDecoder error value
 decoder successDecoder failureDecoder =
-    ResponseDecoder successDecoder failureDecoder
+  ResponseDecoder successDecoder failureDecoder
 
 
 {-| Think `Http.fromJson`, but with additional effort to parse a non-20x response as JSON.
@@ -146,56 +146,74 @@ decoder successDecoder failureDecoder =
 -}
 fromJson : ResponseDecoder error value -> Task Http.RawError Http.Response -> Task (Error error) value
 fromJson decoder response =
-    let
-        onSuccess response str =
-            case decodeString decoder.success str of
-              Ok v -> succeed v
-              Err msg -> fail (HttpError <| Http.UnexpectedPayload str)
+  let
+    onSuccess response str =
+      case decodeString decoder.success str of
+        Ok v ->
+          succeed v
 
-        onError response str =
-            case decodeString decoder.failure str of
-              Ok v -> fail (RailsError v)
-              Err msg -> fail (HttpError <| Http.BadResponse response.status response.statusText)
+        Err msg ->
+          fail (HttpError <| Http.UnexpectedPayload str)
 
-        promoteError rawError =
-            case rawError of
-              Http.RawTimeout -> HttpError Http.Timeout
-              Http.RawNetworkError -> HttpError Http.NetworkError
-    in
-        mapError promoteError response
-            `andThen` handleResponse onSuccess onError
+    onError response str =
+      case decodeString decoder.failure str of
+        Ok v ->
+          fail (RailsError v)
+
+        Err msg ->
+          fail (HttpError <| Http.BadResponse response.status response.statusText)
+
+    promoteError rawError =
+      case rawError of
+        Http.RawTimeout ->
+          HttpError Http.Timeout
+
+        Http.RawNetworkError ->
+          HttpError Http.NetworkError
+  in
+    mapError promoteError response
+      `andThen` handleResponse onSuccess onError
 
 
 type alias ResponseHandler error a =
-    Http.Response -> String -> Task (Error error) a
+  Http.Response -> String -> Task (Error error) a
 
 
-handleResponse : (ResponseHandler error a) -> (ResponseHandler error a) -> Http.Response -> Task (Error error) a
+handleResponse : ResponseHandler error a -> ResponseHandler error a -> Http.Response -> Task (Error error) a
 handleResponse onSuccess onError response =
-    let
-        unexpectedPayloadError =
-            HttpError (Http.UnexpectedPayload "Response body is a blob, expecting a string.")
-    in
-        case 200 <= response.status && response.status < 300 of
-          True ->
-              case response.value of
-                Http.Text str -> onSuccess response str
-                _ -> fail unexpectedPayloadError
+  let
+    unexpectedPayloadError =
+      HttpError (Http.UnexpectedPayload "Response body is a blob, expecting a string.")
+  in
+    case 200 <= response.status && response.status < 300 of
+      True ->
+        case response.value of
+          Http.Text str ->
+            onSuccess response str
 
-          False ->
-              case response.value of
-                Http.Text str -> onError response str
-                _ -> fail unexpectedPayloadError
+          _ ->
+            fail unexpectedPayloadError
+
+      False ->
+        case response.value of
+          Http.Text str ->
+            onError response str
+
+          _ ->
+            fail unexpectedPayloadError
 
 
 {-| If there was a `<meta name="csrf-token">` tag in the page's `<head>` when
-elm-rails loaded, returns the value its `content` attribute had at that time.
+    elm-rails loaded, returns the value its `content` attribute had at that time.
 
-Rails expects this value in the `X-CSRF-Token` header for non-`GET` requests as
-a [CSRF countermeasure](http://guides.rubyonrails.org/security.html#csrf-countermeasures).
+    Rails expects this value in the `X-CSRF-Token` header for non-`GET` requests as
+    a [CSRF countermeasure](http://guides.rubyonrails.org/security.html#csrf-countermeasures).
 -}
 csrfToken : Maybe String
-csrfToken = Native.Rails.csrfToken
+csrfToken =
+  Native.Rails.csrfToken
 
 
-(=>) = (,)
+(=>) : a -> a -> ( a, a )
+(=>) =
+  (,)

--- a/src/Rails.elm
+++ b/src/Rails.elm
@@ -17,6 +17,7 @@ import Maybe
 import String
 
 import Native.Rails
+import String
 
 
 -- Http
@@ -88,11 +89,16 @@ post decoder url body =
 send : String -> String -> Http.Body -> Task Http.RawError Http.Response
 send verb url body =
     let
+        csrfTokenString =
+            Maybe.withDefault "" csrfToken
+
         csrfTokenHeaders =
-            if (String.toUpper verb) == "GET" then
+            if (String.isEmpty csrfTokenString)
+                || ((String.toUpper verb) == "GET")
+            then
                 []
             else
-                [ "X-CSRF-Token" => csrfToken ]
+                [ "X-CSRF-Token" => csrfTokenString ]
 
         requestSettings =
             { verb = verb


### PR DESCRIPTION
# Motivation

Getting an `authToken` currently has to be done through a port. Let's add it to our package instead!
# What I changed
- Added a helper function for getting auth tokens of the type `authToken : Maybe String`
- Added examples of how to use it
# What to test

Check out the example after compiling `examples/Main.elm` with `elm-make examples/Main.elm --output examples/elm.js` from the root.
