### PR TITLE
Auth token refactor

### DIFF
--- a/src/Native/Rails.js
+++ b/src/Native/Rails.js
@@ -10,22 +10,10 @@ Elm.Native.Rails.make = function(localRuntime) {
 
     var $Maybe = Elm.Maybe.make(localRuntime);
 
-    var csrfTokenName = "csrf-token"
-    var csrfToken = $Maybe.Nothing;
-    var potentialMetaNodes = document.head.childNodes;
-
-    // Use this instead of document.querySelector() for pre-ES5 compatibility.
-    for (var index in potentialMetaNodes) {
-        var potentialMetaNode = potentialMetaNodes[index];
-
-        if (potentialMetaNode.tagName === "META"
-            && potentialMetaNode.name === csrfTokenName
-            && (typeof potentialMetaNode.content) === "string")
-        {
-            csrfToken = $Maybe.Just(potentialMetaNode.content);;
-            break;
-        }
-    }
+    var csrfTokenNode = document.querySelector('meta[name="csrf-token"]');
+    var csrfToken = (function() {
+        return (csrfTokenNode === null || (typeof csrfTokenNode.content) !== "string") ? $Maybe.Nothing : $Maybe.Just(csrfTokenNode.content);
+    })();
 
     return localRuntime.Native.Rails.values = {
         csrfToken : csrfToken

--- a/src/Native/Rails.js
+++ b/src/Native/Rails.js
@@ -10,10 +10,22 @@ Elm.Native.Rails.make = function(localRuntime) {
 
     var $Maybe = Elm.Maybe.make(localRuntime);
 
-    var csrfTokenNode = document.querySelector('meta[name="csrf-token"]');
-    var csrfToken = (function() {
-        return (csrfTokenNode === null || tyepof csrfTokenNode.content === "undefined") ? $Maybe.Nothing : $Maybe.Just(csrfTokenNode.content);
-    })();
+    var csrfTokenName = "csrf-token"
+    var csrfToken = $Maybe.Nothing;
+    var potentialMetaNodes = document.head.childNodes;
+
+    // Use this instead of document.querySelector() for pre-ES5 compatibility.
+    for (var index in potentialMetaNodes) {
+        var potentialMetaNode = potentialMetaNodes[index];
+
+        if (potentialMetaNode.tagName === "META"
+            && potentialMetaNode.name === csrfTokenName
+            && (typeof potentialMetaNode.content) === "string")
+        {
+            csrfToken = $Maybe.Just(potentialMetaNode.content);;
+            break;
+        }
+    }
 
     return localRuntime.Native.Rails.values = {
         csrfToken : csrfToken

--- a/src/Native/Rails.js
+++ b/src/Native/Rails.js
@@ -10,16 +10,12 @@ Elm.Native.Rails.make = function(localRuntime) {
 
     var $Maybe = Elm.Maybe.make(localRuntime);
 
-    var metaNode = document.querySelector('meta[name="csrf-token"]');
-
-    var authToken = (function() {
-        if (metaNode === null || typeof metaNode.content === "undefined"){
-            return $Maybe.Nothing;
-        }
-        return $Maybe.Just(metaNode.content);
+    var csrfTokenNode = document.querySelector('meta[name="csrf-token"]');
+    var csrfToken = (function() {
+        return (csrfTokenNode === null || tyepof csrfTokenNode.content === "undefined") ? $Maybe.Nothing : $Maybe.Just(csrfTokenNode.content);
     })();
 
     return localRuntime.Native.Rails.values = {
-        authToken : authToken
+        csrfToken : csrfToken
     };
 }

--- a/src/Native/Rails.js
+++ b/src/Native/Rails.js
@@ -11,9 +11,10 @@ Elm.Native.Rails.make = function(localRuntime) {
     var $Maybe = Elm.Maybe.make(localRuntime);
 
     var csrfTokenNode = document.head.querySelector('meta[name="csrf-token"]');
-    var csrfToken = (function() {
-        return (csrfTokenNode === null || (typeof csrfTokenNode.content) !== "string") ? $Maybe.Nothing : $Maybe.Just(csrfTokenNode.content);
-    })();
+    var csrfToken =
+        (csrfTokenNode === null || (typeof csrfTokenNode.content !== "string"))
+            ? $Maybe.Nothing
+            : $Maybe.Just(csrfTokenNode.content);
 
     return localRuntime.Native.Rails.values = {
         csrfToken : csrfToken

--- a/src/Native/Rails.js
+++ b/src/Native/Rails.js
@@ -10,7 +10,7 @@ Elm.Native.Rails.make = function(localRuntime) {
 
     var $Maybe = Elm.Maybe.make(localRuntime);
 
-    var csrfTokenNode = document.querySelector('meta[name="csrf-token"]');
+    var csrfTokenNode = document.head.querySelector('meta[name="csrf-token"]');
     var csrfToken = (function() {
         return (csrfTokenNode === null || (typeof csrfTokenNode.content) !== "string") ? $Maybe.Nothing : $Maybe.Just(csrfTokenNode.content);
     })();

--- a/src/Rails.elm
+++ b/src/Rails.elm
@@ -41,8 +41,11 @@ send csrfToken decoder verb url body =
         Http.send Http.defaultSettings requestSettings
             |> Http.fromJson decoder
 
-{-| get the rails authToken from the meta tag
-returns nothing if the tag doesn't exist
+{-| If there was a `<meta name="csrf-token">` tag in the page's `<head>` when
+elm-rails loaded, returns the value its `content` attribute had at that time.
+
+Rails expects this value in the `X-CSRF-Token` header for non-`GET` requests as
+a [CSRF countermeasure](http://guides.rubyonrails.org/security.html#csrf-countermeasures).
 -}
 csrfToken : Maybe String
 csrfToken = Native.Rails.csrfToken

--- a/src/Rails.elm
+++ b/src/Rails.elm
@@ -6,7 +6,7 @@ module Rails (send, authToken) where
 @docs send
 
 # Tokens
-@docs authToken
+@docs csrfToken
 
 -}
 
@@ -24,11 +24,11 @@ along with the type of request and a way to decode results.
 
 -}
 send : String -> Decoder value -> String -> String -> Http.Body -> Task Http.Error value
-send authToken decoder verb url body =
+send csrfToken decoder verb url body =
     let
         requestSettings =
             { verb = verb
-            , headers = ["X-CSRF-Token" => authToken
+            , headers = ["X-CSRF-Token" => csrfToken
                         , "Content-Type" => "application/json"
                         , "Accept" => "application/json, text/javascript, */*; q=0.01"
                         , "X-Requested-With" => "XMLHttpRequest"
@@ -44,8 +44,8 @@ send authToken decoder verb url body =
 {-| get the rails authToken from the meta tag
 returns nothing if the tag doesn't exist
 -}
-authToken : Maybe String
-authToken = Native.Rails.authToken
+csrfToken : Maybe String
+csrfToken = Native.Rails.csrfToken
 
 
 (=>) = (,)

--- a/src/Rails.elm
+++ b/src/Rails.elm
@@ -19,20 +19,26 @@ import Native.Rails
 
 -- Http
 
-{-| Utility for working with rails. Wraps Http.send passing an Authenticity Token
+{-| Utility for working with rails. Wraps Http.send passing a CSRF Token
 along with the type of request and a way to decode results.
-
 -}
-send : String -> Decoder value -> String -> String -> Http.Body -> Task Http.Error value
-send csrfToken decoder verb url body =
+send : Decoder value -> String -> String -> Http.Body -> Task Http.Error value
+send decoder verb url body =
     let
+        csrfTokenHeaders =
+            if (String.toUpper verb) == "GET" then
+                []
+            else
+                [ "X-CSRF-Token" => csrfToken ]
+
         requestSettings =
             { verb = verb
-            , headers = ["X-CSRF-Token" => csrfToken
-                        , "Content-Type" => "application/json"
-                        , "Accept" => "application/json, text/javascript, */*; q=0.01"
-                        , "X-Requested-With" => "XMLHttpRequest"
-                        ]
+            , headers =
+                csrfTokenHeaders ++
+                    [ "Content-Type" => "application/json"
+                    , "Accept" => "application/json, text/javascript, */*; q=0.01"
+                    , "X-Requested-With" => "XMLHttpRequest"
+                    ]
             , url = url
             , body = body
             }

--- a/src/Rails.elm
+++ b/src/Rails.elm
@@ -19,7 +19,7 @@ import Native.Rails
 
 -- Http
 
-{-| Utility for working with rails. Wraps Http.send passing a CSRF Token
+{-| Utility for working with Rails. Wraps Http.send passing a CSRF Token
 along with the type of request and a way to decode results.
 -}
 send : Decoder value -> String -> String -> Http.Body -> Task Http.Error value


### PR DESCRIPTION
- Renamed to `csrfToken` to match Rails docs
- Simplified some stuff
- Have `send` automatically use the token appropriately.
