### PR TITLE
Add Elm 0.16 Support

### DIFF
--- a/elm-package.json
+++ b/elm-package.json
@@ -11,8 +11,8 @@
         "Rails.Decode"
     ],
     "dependencies": {
-        "elm-lang/core": "2.1.0 <= v < 3.0.0",
-        "evancz/elm-http": "2.0.0 <= v < 3.0.0"
+        "elm-lang/core": "2.1.0 <= v < 4.0.0",
+        "evancz/elm-http": "2.0.0 <= v < 4.0.0"
     },
-    "elm-version": "0.15.1 <= v < 0.16.0"
+    "elm-version": "0.15.0 <= v < 0.17.0"
 }

--- a/elm-package.json
+++ b/elm-package.json
@@ -1,5 +1,5 @@
 {
-    "version": "2.0.0",
+    "version": "3.0.0",
     "summary": "Convenience functions for using Elm with Rails.",
     "repository": "https://github.com/NoRedInk/elm-rails.git",
     "license": "BSD-3-Clause",


### PR DESCRIPTION
No changes needed; just expanding acceptable version bounds in elm-package.json.
