### PR TITLE
WIP: 0.18 and csrfToken : Result String String

### DIFF
--- a/elm-package.json
+++ b/elm-package.json
@@ -12,7 +12,8 @@
     ],
     "native-modules": true,
     "dependencies": {
-        "elm-lang/core": "5.0.0 <= v <= 6.0.0"
+        "elm-lang/core": "5.0.0 <= v <= 6.0.0",
+        "elm-lang/http": "1.0.0 <= v < 2.0.0"
     },
     "elm-version": "0.18.0 <= v < 0.19.0"
 }

--- a/elm-package.json
+++ b/elm-package.json
@@ -12,8 +12,7 @@
     ],
     "native-modules": true,
     "dependencies": {
-        "elm-lang/core": "4.0.0 <= v <= 5.0.0",
-        "evancz/elm-http": "3.0.1 <= v < 4.0.0"
+        "elm-lang/core": "5.0.0 <= v <= 6.0.0"
     },
-    "elm-version": "0.17.0 <= v < 0.18.0"
+    "elm-version": "0.18.0 <= v < 0.19.0"
 }

--- a/elm-package.json
+++ b/elm-package.json
@@ -1,5 +1,5 @@
 {
-    "version": "4.0.6",
+    "version": "5.0.0",
     "summary": "Convenience functions for using Elm with Rails.",
     "repository": "https://github.com/NoRedInk/elm-rails.git",
     "license": "BSD-3-Clause",

--- a/examples/Main.elm
+++ b/examples/Main.elm
@@ -1,15 +1,16 @@
 module Main exposing (..)
 
 import Rails
-import Html exposing (div, text)
+import Html exposing (div, text, Html)
 
 
+main : Html msg
 main =
     div []
         [ case Rails.csrfToken of
-            Nothing ->
-                text "Nothing"
+            Err err ->
+                text ("csrfToken error: " ++ err)
 
-            Just v ->
+            Ok v ->
                 text v
         ]

--- a/examples/elm-package.json
+++ b/examples/elm-package.json
@@ -10,9 +10,9 @@
     "exposed-modules": [],
     "native-modules": true,
     "dependencies": {
-        "elm-lang/core": "4.0.0 <= v <= 5.0.0",
-        "elm-lang/html": "1.0.0 <= v < 2.0.0",
-        "evancz/elm-http": "3.0.1 <= v < 4.0.0"
+        "elm-lang/core": "5.0.0 <= v <= 6.0.0",
+        "elm-lang/html": "2.0.0 <= v < 3.0.0",
+        "elm-lang/http": "1.0.0 <= v < 2.0.0"
     },
-    "elm-version": "0.17.0 <= v < 0.18.0"
+    "elm-version": "0.18.0 <= v < 0.19.0"
 }

--- a/src/Native/Rails.js
+++ b/src/Native/Rails.js
@@ -3,10 +3,9 @@ var _NoRedInk$elm_rails$Native_Rails = function(){
     // when we aren't in an actual dom, short curcuit
     // we can't always trust this test because mocking
     if (typeof window === "undefined"){
-      return { ctor : 'Nothing' };
+      return { ctor: 'Err', _0: "Could not read <meta name=\"csrf-token\"> because window was undefined." };
     }
 
-    var csrfToken = { ctor: 'Nothing' };
     var csrfTokenNode = null;
 
     try {
@@ -15,9 +14,10 @@ var _NoRedInk$elm_rails$Native_Rails = function(){
       // ignore document-based errors
     }
 
-    if ((csrfTokenNode !== null) && (typeof csrfTokenNode.content === "string")){
-      csrfToken = { ctor: 'Just', _0: csrfTokenNode.content };
-    }
+    var csrfToken =
+      ((csrfTokenNode !== null) && (typeof csrfTokenNode.content === "string"))
+        ? { ctor: 'Ok', _0: csrfTokenNode.content }
+        : { ctor: 'Err', _0: "<meta name=\"csrf-token\"> was not found in document.head." };
 
     return csrfToken;
   };

--- a/src/Native/Rails.js
+++ b/src/Native/Rails.js
@@ -14,12 +14,11 @@ var _NoRedInk$elm_rails$Native_Rails = function(){
       // ignore document-based errors
     }
 
-    var csrfToken =
-      ((csrfTokenNode !== null) && (typeof csrfTokenNode.content === "string"))
-        ? { ctor: 'Ok', _0: csrfTokenNode.content }
-        : { ctor: 'Err', _0: "<meta name=\"csrf-token\"> was not found in document.head." };
-
-    return csrfToken;
+    if ((csrfTokenNode !== null) && (typeof csrfTokenNode.content === "string")) {
+      return { ctor: 'Ok', _0: csrfTokenNode.content };
+    } else {
+      return { ctor: 'Err', _0: "<meta name=\"csrf-token\"> was not found in document.head." };
+    }
   };
 
   return {

--- a/src/Rails.elm
+++ b/src/Rails.elm
@@ -13,7 +13,7 @@ module Rails exposing (Error(..), get, post, send, fromJson, always, decoder, cs
 import Http
 import Task exposing (Task, succeed, fail, mapError, andThen)
 import Json.Decode exposing (Decoder, decodeString)
-import Maybe
+import Result exposing (Result)
 import String
 import Native.Rails
 
@@ -209,7 +209,7 @@ handleResponse onSuccess onError response =
     Rails expects this value in the `X-CSRF-Token` header for non-`GET` requests as
     a [CSRF countermeasure](http://guides.rubyonrails.org/security.html#csrf-countermeasures).
 -}
-csrfToken : Maybe String
+csrfToken : Result String String
 csrfToken =
   Native.Rails.csrfToken
 

--- a/src/Rails.elm
+++ b/src/Rails.elm
@@ -118,7 +118,6 @@ post url body responseDecoder =
 {-| Wraps `Http.request` while adding the following default headers:
 
 * `X-CSRF-Token` - set to `csrfToken` if it's an `Ok` and this request isn't a `GET`
-* `Content-Type` - `"application/json"`
 * `Accept` - `"application/json, text/javascript, */*; q=0.01"`
 * `X-Requested-With` - `"XMLHttpRequest"`
 
@@ -183,8 +182,7 @@ request options =
 
 defaultRequestHeaders : List Header
 defaultRequestHeaders =
-    [ Http.header "Content-Type" "application/json"
-    , Http.header "Accept" "application/json, text/javascript, */*; q=0.01"
+    [ Http.header "Accept" "application/json, text/javascript, */*; q=0.01"
     , Http.header "X-Requested-With" "XMLHttpRequest"
     ]
 

--- a/src/Rails.elm
+++ b/src/Rails.elm
@@ -107,11 +107,11 @@ request :
     , headers : List Header
     , url : String
     , body : Body
-    , expect : Expect (Result error success)
+    , expect : Expect a
     , timeout : Maybe Time
     , withCredentials : Bool
     }
-    -> Request (Result error success)
+    -> Request a
 request options =
     let
         csrfTokenString =

--- a/src/Rails.elm
+++ b/src/Rails.elm
@@ -24,8 +24,8 @@ import Native.Rails
 {-| The kinds of errors a Rails server may return.
 -}
 type Error error
-  = HttpError Http.Error
-  | RailsError error
+    = HttpError Http.Error
+    | RailsError error
 
 
 {-| Send a GET request to the given URL. You also specify how to decode the response.
@@ -39,7 +39,7 @@ type Error error
 -}
 get : ResponseDecoder error value -> String -> Task (Error error) value
 get decoder url =
-  fromJson decoder (send "GET" url Http.empty)
+    fromJson decoder (send "GET" url Http.empty)
 
 
 {-| Send a POST request to the given URL. You also specify how to decode the response.
@@ -54,7 +54,7 @@ get decoder url =
 -}
 post : ResponseDecoder error value -> String -> Http.Body -> Task (Error error) value
 post decoder url body =
-  fromJson decoder (send "POST" url body)
+    fromJson decoder (send "POST" url body)
 
 
 {-| Utility for working with Rails. Wraps Http.send, passing an Authenticity Token along with the type of request. Suitable for use with `fromJson`:
@@ -87,54 +87,54 @@ post decoder url body =
 -}
 send : String -> String -> Http.Body -> Task Http.RawError Http.Response
 send verb url body =
-  let
-    csrfTokenString =
-      Maybe.withDefault "" csrfToken
+    let
+        csrfTokenString =
+            Result.withDefault "" csrfToken
 
-    csrfTokenHeaders =
-      if
-        (String.isEmpty csrfTokenString)
-          || ((String.toUpper verb) == "GET")
-      then
-        []
-      else
-        [ "X-CSRF-Token" => csrfTokenString ]
+        csrfTokenHeaders =
+            if
+                (String.isEmpty csrfTokenString)
+                    || ((String.toUpper verb) == "GET")
+            then
+                []
+            else
+                [ "X-CSRF-Token" => csrfTokenString ]
 
-    requestSettings =
-      { verb = verb
-      , headers =
-          csrfTokenHeaders
-            ++ [ "Content-Type" => "application/json"
-               , "Accept" => "application/json, text/javascript, */*; q=0.01"
-               , "X-Requested-With" => "XMLHttpRequest"
-               ]
-      , url = url
-      , body = body
-      }
-  in
-    Http.send Http.defaultSettings requestSettings
+        requestSettings =
+            { verb = verb
+            , headers =
+                csrfTokenHeaders
+                    ++ [ "Content-Type" => "application/json"
+                       , "Accept" => "application/json, text/javascript, */*; q=0.01"
+                       , "X-Requested-With" => "XMLHttpRequest"
+                       ]
+            , url = url
+            , body = body
+            }
+    in
+        Http.send Http.defaultSettings requestSettings
 
 
 {-| JSON Decoders for parsing an HTTP response body.
 -}
 type alias ResponseDecoder error value =
-  { success : Decoder value
-  , failure : Decoder error
-  }
+    { success : Decoder value
+    , failure : Decoder error
+    }
 
 
 {-| Returns a decoder suitable for passing to `fromJson`, which uses the same decoder for both success and failure responses.
 -}
 always : Decoder value -> ResponseDecoder value value
 always decoder =
-  ResponseDecoder decoder decoder
+    ResponseDecoder decoder decoder
 
 
 {-| Returns a decoder suitable for passing to `fromJson`.
 -}
 decoder : Decoder value -> Decoder error -> ResponseDecoder error value
 decoder successDecoder failureDecoder =
-  ResponseDecoder successDecoder failureDecoder
+    ResponseDecoder successDecoder failureDecoder
 
 
 {-| Think `Http.fromJson`, but with additional effort to parse a non-20x response as JSON.
@@ -146,61 +146,61 @@ decoder successDecoder failureDecoder =
 -}
 fromJson : ResponseDecoder error value -> Task Http.RawError Http.Response -> Task (Error error) value
 fromJson decoder response =
-  let
-    onSuccess response str =
-      case decodeString decoder.success str of
-        Ok v ->
-          succeed v
+    let
+        onSuccess response str =
+            case decodeString decoder.success str of
+                Ok v ->
+                    succeed v
 
-        Err msg ->
-          fail (HttpError <| Http.UnexpectedPayload str)
+                Err msg ->
+                    fail (HttpError <| Http.UnexpectedPayload str)
 
-    onError response str =
-      case decodeString decoder.failure str of
-        Ok v ->
-          fail (RailsError v)
+        onError response str =
+            case decodeString decoder.failure str of
+                Ok v ->
+                    fail (RailsError v)
 
-        Err msg ->
-          fail (HttpError <| Http.BadResponse response.status response.statusText)
+                Err msg ->
+                    fail (HttpError <| Http.BadResponse response.status response.statusText)
 
-    promoteError rawError =
-      case rawError of
-        Http.RawTimeout ->
-          HttpError Http.Timeout
+        promoteError rawError =
+            case rawError of
+                Http.RawTimeout ->
+                    HttpError Http.Timeout
 
-        Http.RawNetworkError ->
-          HttpError Http.NetworkError
-  in
-    mapError promoteError response
-      `andThen` handleResponse onSuccess onError
+                Http.RawNetworkError ->
+                    HttpError Http.NetworkError
+    in
+        mapError promoteError response
+            `andThen` handleResponse onSuccess onError
 
 
 type alias ResponseHandler error a =
-  Http.Response -> String -> Task (Error error) a
+    Http.Response -> String -> Task (Error error) a
 
 
 handleResponse : ResponseHandler error a -> ResponseHandler error a -> Http.Response -> Task (Error error) a
 handleResponse onSuccess onError response =
-  let
-    unexpectedPayloadError =
-      HttpError (Http.UnexpectedPayload "Response body is a blob, expecting a string.")
-  in
-    case 200 <= response.status && response.status < 300 of
-      True ->
-        case response.value of
-          Http.Text str ->
-            onSuccess response str
+    let
+        unexpectedPayloadError =
+            HttpError (Http.UnexpectedPayload "Response body is a blob, expecting a string.")
+    in
+        case 200 <= response.status && response.status < 300 of
+            True ->
+                case response.value of
+                    Http.Text str ->
+                        onSuccess response str
 
-          _ ->
-            fail unexpectedPayloadError
+                    _ ->
+                        fail unexpectedPayloadError
 
-      False ->
-        case response.value of
-          Http.Text str ->
-            onError response str
+            False ->
+                case response.value of
+                    Http.Text str ->
+                        onError response str
 
-          _ ->
-            fail unexpectedPayloadError
+                    _ ->
+                        fail unexpectedPayloadError
 
 
 {-| If there was a `<meta name="csrf-token">` tag in the page's `<head>` when
@@ -211,9 +211,9 @@ handleResponse onSuccess onError response =
 -}
 csrfToken : Result String String
 csrfToken =
-  Native.Rails.csrfToken
+    Native.Rails.csrfToken
 
 
 (=>) : a -> a -> ( a, a )
 (=>) =
-  (,)
+    (,)

--- a/src/Rails.elm
+++ b/src/Rails.elm
@@ -160,17 +160,16 @@ request :
     -> Request a
 request options =
     let
-        csrfTokenString =
-            Result.withDefault "" csrfToken
-
         csrfTokenHeaders =
-            if
-                String.isEmpty csrfTokenString
-                    || ((String.toUpper options.method) == "GET")
-            then
+            if (String.toUpper options.method) == "GET" then
                 []
             else
-                [ Http.header "X-CSRF-Token" csrfTokenString ]
+                case csrfToken of
+                    Err _ ->
+                        []
+
+                    Ok csrfTokenString ->
+                        [ Http.header "X-CSRF-Token" csrfTokenString ]
 
         headers =
             List.concat

--- a/src/Rails/Decode.elm
+++ b/src/Rails/Decode.elm
@@ -10,9 +10,10 @@ Types
 
 -}
 
-import Json.Decode as Decode exposing (Decoder, (:=))
+import Json.Decode as Decode exposing (Decoder, field)
 import Result exposing (Result)
 import Dict
+
 
 {-| ErrorList is a type alias for
 a list of fields to String, where `field` is expected to be a type for matching
@@ -26,9 +27,12 @@ decode : ErrorList Field
 ```
 -}
 type alias ErrorList field =
-    List (field, String)
+    List ( field, String )
+
+
 
 -- Decoding
+
 
 {-| Decodes errors passed from rails formatted as
 
@@ -52,47 +56,48 @@ Dict.fromList
 errors : Dict.Dict String field -> Decoder (ErrorList field)
 errors mappings =
     let
-        errorsDecoder : Decoder (List (String, List String))
+        errorsDecoder : Decoder (List ( String, List String ))
         errorsDecoder =
             Decode.keyValuePairs (Decode.list Decode.string)
 
-        --finalDecoder : Decoder (ErrorList field)
+        finalDecoder : Decoder (ErrorList field)
         finalDecoder =
-            Decode.customDecoder errorsDecoder (toFinalDecoder [])
+            errorsDecoder
+                |> Decode.andThen (toFinalDecoder [])
 
-        --fieldDecoderFor : String -> Decoder field
+        fieldDecoderFor : String -> Decoder field
         fieldDecoderFor fieldName =
             Dict.get fieldName mappings
                 |> Maybe.map Decode.succeed
                 |> Maybe.withDefault (Decode.fail ("Unrecognized Field: " ++ fieldName))
 
-
-        -- toFinalDecoder : List (field, String) -> List (String, (List String)) -> Result String (List (field, String))
+        toFinalDecoder :
+            List ( field, String )
+            -> List ( String, List String )
+            -> Decoder (List ( field, String ))
         toFinalDecoder results rawErrors =
             case rawErrors of
                 [] ->
-                    Ok results
+                    Decode.succeed results
 
-                (fieldName, errors) :: others ->
+                ( fieldName, errors ) :: others ->
                     let
-                        --newResults : Result String (ErrorList field)
+                        newResults : Result String (ErrorList field)
                         newResults =
                             Decode.decodeString (fieldDecoderFor fieldName) ("\"" ++ fieldName ++ "\"")
                                 |> Result.map (tuplesFromField errors results)
-
                     in
                         case newResults of
-                            Err _ ->
-                                newResults
+                            Err err ->
+                                Decode.fail err
 
                             Ok newResultList ->
                                 toFinalDecoder newResultList others
 
-        --tuplesFromField : List String -> (ErrorList field) -> field -> (ErrorList field)
+        tuplesFromField : List String -> ErrorList field -> field -> ErrorList field
         tuplesFromField errors results field =
             errors
-                |> List.map (\error -> (field, error))
+                |> List.map (\error -> ( field, error ))
                 |> List.append results
-
     in
-        "errors" := finalDecoder
+        field "errors" finalDecoder

--- a/src/Rails/Decode.elm
+++ b/src/Rails/Decode.elm
@@ -15,15 +15,13 @@ import Result exposing (Result)
 import Dict
 
 
-{-| ErrorList is a type alias for
-a list of fields to String, where `field` is expected to be a type for matching
-errors to
-```
+{-| ErrorList is a type alias for a list of `( fields, String )` pairs,
+where `field` is a type we can use to reference which fields had errors.
 
+```
 type Field = Name | Password
 
 decode : ErrorList Field
-
 ```
 -}
 type alias ErrorList field =
@@ -34,12 +32,12 @@ type alias ErrorList field =
 -- Decoding
 
 
-{-| Decodes errors passed from rails formatted as
+{-| Decodes errors passed from rails formatted like this:
 
 `{ errors: {errorName: ["Error String"] } }`.
 
-This function takes a Dict that is a map of all the fields you need decoded. It should be formatted
-nest
+This function takes a Dict that is a map of all the fields you need decoded.
+It should look like this:
 
 ```
 Dict.fromList


### PR DESCRIPTION
WIP because I need to update documentation.

What I changed:

* `csrfToken` is now `Result String String`, per https://github.com/NoRedInk/elm-rails/issues/12
* Updated everything to 0.18, per https://github.com/NoRedInk/elm-rails/issues/13
* `request` is the new `send`
* I preserved the `RailsError` information by having the convenience functions return `Request (Result error success)` instead of `Request a` - so you can use these with `Http.send` as normal, and then `case` the result on the other side to handle rails-specific errors. (In such a response, the `Err` case is where you'd find the info previously contained in `RailsError`.)
* I made the argument order in `get` and `post` mirror what they are in `Http`

@eeue56 wanted to run the changes by you before updating docs - when I dug into it, it actually seemed like a good idea to keep `get` and `post` after all.

LMK what you think!