### PR TITLE
New API: 6.0.0

### DIFF
--- a/src/Rails.elm
+++ b/src/Rails.elm
@@ -194,6 +194,8 @@ delete url body responseDecoder =
 * `Accept` - `"application/json, text/javascript, */*; q=0.01"`
 * `X-Requested-With` - `"XMLHttpRequest"`
 
+You can specify additional headers in the `headers` field of the configuration record.
+
     import Dict
     import Json.Decode exposing (list, string)
     import Json.Encode as Encode


### PR DESCRIPTION
Turns out the 5.0.0 API was built on my not realizing [`Http.Error`](http://package.elm-lang.org/packages/elm-lang/http/1.0.0/Http#Error) incorporates `BadStatus` now, which automatically translates non-200 response status codes into a `Http.Error`.

This means two things:

1. 5.0.0 is broken because responses are not properly decoded using the Rails decoder.
2. This new 6.0.0 API can be a lot simpler!

Now we don't to return `Request` values that hold `Result` vales, or to have a `RailsDecoder` anymore. Instead we can have each `Request` specify just the success decoder, and have a `decodeErrors` function that works with `Http.send` to decode Rails-specific errors.