### PR TITLE
Decode raw errors

### DIFF
--- a/run-tests.sh
+++ b/run-tests.sh
@@ -1,6 +1,11 @@
 #!/bin/bash
 
+if [ ! -e node_modules/.bin/elm-test ]; then
+    npm install elm-test
+fi
+
 set -ex
 
+node_modules/.bin/elm-test
 elm-make --yes
 (cd examples; elm-make --yes Main.elm)

--- a/run-tests.sh
+++ b/run-tests.sh
@@ -1,0 +1,6 @@
+#!/bin/bash
+
+set -ex
+
+elm-make --yes
+(cd examples; elm-make --yes Main.elm)

--- a/tests/.gitignore
+++ b/tests/.gitignore
@@ -1,0 +1,1 @@
+/elm-stuff/

--- a/tests/Main.elm
+++ b/tests/Main.elm
@@ -1,0 +1,13 @@
+port module Main exposing (..)
+
+import Tests
+import Test.Runner.Node exposing (run, TestProgram)
+import Json.Encode exposing (Value)
+
+
+main : TestProgram
+main =
+    run emit Tests.all
+
+
+port emit : ( String, Value ) -> Cmd msg

--- a/tests/RailsTests.elm
+++ b/tests/RailsTests.elm
@@ -2,9 +2,42 @@ module RailsTests exposing (all)
 
 import Test exposing (..)
 import Expect exposing (Expectation)
+import Rails
+import Json.Decode
+import Http
+import Dict
 
 
 all : Test
 all =
     describe "Rails"
-        []
+        [ describe "decodeErrors"
+            [ test "Passes through Ok values" <|
+                \() ->
+                    Ok ()
+                        |> Rails.decodeErrors Json.Decode.string
+                        |> Expect.equal (Ok ())
+            , test "Parses the body of BadStatus errors" <|
+                \() ->
+                    Err
+                        (Http.BadStatus
+                            { url = ""
+                            , status = { code = 400, message = "" }
+                            , headers = Dict.empty
+                            , body = "\"custom error\""
+                            }
+                        )
+                        |> Rails.decodeErrors Json.Decode.string
+                        |> expectErr (.rails >> Expect.equal (Just "custom error"))
+            ]
+        ]
+
+
+expectErr : (x -> Expectation) -> Result x a -> Expectation
+expectErr check result =
+    case result of
+        Err x ->
+            check x
+
+        Ok _ ->
+            Expect.fail ("Expected (Err _), but got: " ++ toString result)

--- a/tests/RailsTests.elm
+++ b/tests/RailsTests.elm
@@ -1,0 +1,10 @@
+module RailsTests exposing (all)
+
+import Test exposing (..)
+import Expect exposing (Expectation)
+
+
+all : Test
+all =
+    describe "Rails"
+        []

--- a/tests/RailsTests.elm
+++ b/tests/RailsTests.elm
@@ -30,6 +30,19 @@ all =
                         |> Rails.decodeErrors Json.Decode.string
                         |> expectErr (.rails >> Expect.equal (Just "custom error"))
             ]
+        , describe "decodeRawErrors"
+            [ test "Parses the body of BadStatus errors" <|
+                \() ->
+                    Http.BadStatus
+                        { url = ""
+                        , status = { code = 400, message = "" }
+                        , headers = Dict.empty
+                        , body = "\"custom error\""
+                        }
+                        |> Rails.decodeRawErrors Json.Decode.string
+                        |> .rails
+                        |> Expect.equal (Just "custom error")
+            ]
         ]
 
 

--- a/tests/Tests.elm
+++ b/tests/Tests.elm
@@ -1,0 +1,11 @@
+module Tests exposing (..)
+
+import Test exposing (..)
+import RailsTests
+
+
+all : Test
+all =
+    describe "elm-rails"
+        [ RailsTests.all
+        ]

--- a/tests/elm-package.json
+++ b/tests/elm-package.json
@@ -1,0 +1,20 @@
+{
+    "version": "1.0.0",
+    "summary": "Sample Elm Test",
+    "repository": "https://github.com/user/project.git",
+    "license": "BSD-3-Clause",
+    "source-directories": [
+        ".",
+        "../src"
+    ],
+    "exposed-modules": [],
+    "dependencies": {
+        "elm-community/json-extra": "2.0.0 <= v < 3.0.0",
+        "elm-lang/html": "2.0.0 <= v < 3.0.0",
+        "mgold/elm-random-pcg": "4.0.2 <= v < 5.0.0",
+        "elm-lang/core": "5.0.0 <= v < 6.0.0",
+        "elm-community/elm-test": "3.0.0 <= v < 4.0.0",
+        "rtfeldman/node-test-runner": "3.0.0 <= v < 4.0.0"
+    },
+    "elm-version": "0.18.0 <= v < 0.19.0"
+}

--- a/tests/elm-package.json
+++ b/tests/elm-package.json
@@ -1,16 +1,18 @@
 {
     "version": "1.0.0",
     "summary": "Sample Elm Test",
-    "repository": "https://github.com/user/project.git",
+    "repository": "https://github.com/NoRedInk/elm-rails.git",
     "license": "BSD-3-Clause",
     "source-directories": [
         ".",
         "../src"
     ],
     "exposed-modules": [],
+    "native-modules": true,
     "dependencies": {
         "elm-community/json-extra": "2.0.0 <= v < 3.0.0",
         "elm-lang/html": "2.0.0 <= v < 3.0.0",
+        "elm-lang/http": "1.0.0 <= v < 2.0.0",
         "mgold/elm-random-pcg": "4.0.2 <= v < 5.0.0",
         "elm-lang/core": "5.0.0 <= v < 6.0.0",
         "elm-community/elm-test": "3.0.0 <= v < 4.0.0",


### PR DESCRIPTION
The first three commits set up `elm-test` and add tests for `Rails.decodeErrors`.  This is a minor version change.

The final commit implements this feature, which adds a function to decode `Http.Error` into `Rails.Error` without having to wrap it in a `Result` first.  This is desirable when using `Http.toTask` with `elm-rails`, for instance: 

```
Rails.post ... |> Http.toTask |> Http.mapError (Rails.decodeRawErrors errorDecoder)
```
which cannot easily be done with the existing `Rails.decodeErrors`.


Ideally, I think it would be better to call the new function `decodeErrors` and remove the existing `decodeErrors` or call it `decodeResultErrors`, but either of those would be a major version bump, so I avoided doing it.